### PR TITLE
해시테그 검색 페이지 이동 기능 구현

### DIFF
--- a/fc-project-board/src/main/resources/templates/articles/detail.th.xml
+++ b/fc-project-board/src/main/resources/templates/articles/detail.th.xml
@@ -14,7 +14,7 @@
 
     <attr sel="#article-buttons">
         <attr sel="#delete-article-form" th:action="'/articles/' + *{id} + '/delete'" th:method="post">
-            <attr sel="#update-article" th:href="'articles/' + *{id} + '/form'"/>
+            <attr sel="#update-article" th:href="'/articles/' + *{id} + '/form'"/>
         </attr>
     </attr>
 
@@ -29,12 +29,12 @@
     <attr sel="#pagination">
         <attr sel="ul">
             <attr sel="li[0]/a"
-                  th:href="*{id} - 1 <= 0 ? '#' : |/articles/*{id - 1}"
+                  th:href="*{id} - 1 <= 0 ? '#' : |/articles/*{id - 1}|"
                   th:class="'page-link' + (*{id} - 1 <= 0 ? ' disabled' : '')"
             />
             <attr sel="li[1]/a"
-                  th:href="*{id} + 1 > ${totalCount} ? '#' : |/articles/*{id + 1}"
-                  th:class="'page-link' + (*{id} + 1 > 0 ? ' disabled' : '')"
+                  th:href="*{id} + 1 > ${totalCount} ? '#' : |/articles/*{id + 1}|"
+                  th:class="'page-link' + (*{id} + 1 > ${totalCount} ? ' disabled' : '')"
             />
         </attr>
     </attr>

--- a/fc-project-board/src/main/resources/templates/header.html
+++ b/fc-project-board/src/main/resources/templates/header.html
@@ -10,7 +10,8 @@
         <div class="container">
             <div class="d-flex flex-wrap align-items-center justify-content-center justify-content-lg-start">
                 <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
-                    <li><a href="/" class="nav-link px-2 text-secondary">Home</a></li>
+                    <li><a id="home" href="#" class="nav-link px-2 text-secondary">Home</a></li>
+                    <li><a id="hashtag" href="#" class="nav-link px-2 text-secondary">Hashtags</a></li>
                 </ul>
                 
                 <div class="text-end">

--- a/fc-project-board/src/main/resources/templates/header.th.xml
+++ b/fc-project-board/src/main/resources/templates/header.th.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#home" th:href="@{/}" />
+    <attr sel="#hashtag" th:href="@{/articles/search-hashtag}" />
+</thlogic>


### PR DESCRIPTION
### 해시태그 검색 페이지의 이동기능 부재 수정

- 헤더에서 해시태그 검색 페이지로 이동할 수 있도록 경로 추가
- 게시글 수정 경로 오타 수정

This closes #51 