### PR TITLE
인증 기능 구현

### DIFF
--- a/fc-project-board/src/main/java/com/fc/projectboard/config/JpaConfig.java
+++ b/fc-project-board/src/main/java/com/fc/projectboard/config/JpaConfig.java
@@ -1,9 +1,13 @@
 package com.fc.projectboard.config;
 
+import com.fc.projectboard.dto.security.BoardPrincipal;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.Optional;
 
@@ -13,6 +17,12 @@ public class JpaConfig {
 
     @Bean
     public AuditorAware<String> auditorAware() {
-        return () -> Optional.of("fkaa"); // TODO : Security 인증 기능 설정 후 수정 필요
+        return () -> Optional.ofNullable(SecurityContextHolder.getContext())
+                .map(SecurityContext::getAuthentication)
+                .filter(Authentication::isAuthenticated)
+                .map(Authentication::getPrincipal)
+                .map(BoardPrincipal.class::cast)
+                .map(BoardPrincipal::getUsername);
+
     }
 }

--- a/fc-project-board/src/main/java/com/fc/projectboard/config/SecurityConfig.java
+++ b/fc-project-board/src/main/java/com/fc/projectboard/config/SecurityConfig.java
@@ -1,8 +1,17 @@
 package com.fc.projectboard.config;
 
+import com.fc.projectboard.dto.UserAccountDto;
+import com.fc.projectboard.dto.security.BoardPrincipal;
+import com.fc.projectboard.repository.UserAccountRepository;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -10,8 +19,32 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        return http.authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+        return http.authorizeHttpRequests(auth -> auth
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .mvcMatchers(
+                                HttpMethod.GET,
+                                "/",
+                                "/articles",
+                                "/articles/search-hashtag"
+                        ).permitAll()
+                        .anyRequest().authenticated())
                 .formLogin().and()
+                .logout()
+                    .logoutSuccessUrl("/").and()
                 .build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService(UserAccountRepository userAccountRepository) {
+        return username -> userAccountRepository
+                .findById(username)
+                .map(UserAccountDto::from)
+                .map(BoardPrincipal::from)
+                .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없습니다 - username : " + username));
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 }

--- a/fc-project-board/src/main/java/com/fc/projectboard/controller/ArticleCommentController.java
+++ b/fc-project-board/src/main/java/com/fc/projectboard/controller/ArticleCommentController.java
@@ -2,8 +2,10 @@ package com.fc.projectboard.controller;
 
 import com.fc.projectboard.dto.UserAccountDto;
 import com.fc.projectboard.dto.request.ArticleCommentRequest;
+import com.fc.projectboard.dto.security.BoardPrincipal;
 import com.fc.projectboard.service.ArticleCommentService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,19 +19,22 @@ public class ArticleCommentController {
     private final ArticleCommentService articleCommentService;
 
     @PostMapping("/new")
-    public String postNewArticleComment(ArticleCommentRequest articleCommentRequest) {
+    public String postNewArticleComment(
+            @AuthenticationPrincipal BoardPrincipal boardPrincipal,
+            ArticleCommentRequest articleCommentRequest) {
 
         // TODO : 인증정보 필요
-        articleCommentService.saveArticleComment(articleCommentRequest.toDto(UserAccountDto.of(
-                "fkaa", "asdf1234", "fkaa@mail.com", "fkaa", "memeo"
-        )));
+        articleCommentService.saveArticleComment(articleCommentRequest.toDto(boardPrincipal.toDto()));
 
         return "redirect:/articles/" + articleCommentRequest.articleId();
     }
 
     @PostMapping("/{commentId}/delete")
-    public String deleteArticleComment(@PathVariable Long commentId, Long articleId) {
-        articleCommentService.deleteArticleComment(commentId);
+    public String deleteArticleComment(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal BoardPrincipal boardPrincipal,
+            Long articleId) {
+        articleCommentService.deleteArticleComment(commentId, boardPrincipal.getUsername());
 
         return "redirect:/articles/" + articleId;
     }

--- a/fc-project-board/src/main/java/com/fc/projectboard/controller/ArticleController.java
+++ b/fc-project-board/src/main/java/com/fc/projectboard/controller/ArticleController.java
@@ -6,6 +6,7 @@ import com.fc.projectboard.dto.UserAccountDto;
 import com.fc.projectboard.dto.request.ArticleRequest;
 import com.fc.projectboard.dto.response.ArticleResponse;
 import com.fc.projectboard.dto.response.ArticleWithCommentsResponse;
+import com.fc.projectboard.dto.security.BoardPrincipal;
 import com.fc.projectboard.service.ArticleService;
 import com.fc.projectboard.service.PaginationService;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.*;
@@ -84,11 +86,10 @@ public class ArticleController {
     }
 
     @PostMapping("form")
-    public String postNewArticle(ArticleRequest articleRequest) {
-        //TODO: 인증정보 필요
-        articleService.saveArticle(articleRequest.toDto(UserAccountDto.of(
-                "fkaa", "asdf1234", "fkaa@email.com", "fkaa", "memo"
-        )));
+    public String postNewArticle(
+            ArticleRequest articleRequest,
+            @AuthenticationPrincipal BoardPrincipal boardPrincipal) {
+        articleService.saveArticle(articleRequest.toDto(boardPrincipal.toDto()));
 
         return "redirect:/articles";
     }
@@ -104,19 +105,18 @@ public class ArticleController {
     }
 
     @PostMapping("/{articleId}/form")
-    public String updateArticle(@PathVariable Long articleId, ArticleRequest articleRequest) {
-        //TODO : 인증정보 필요
-        articleService.updateArticle(articleId, articleRequest.toDto(UserAccountDto.of(
-                "fkaa", "asdf1234", "fkaa@emai.com", "fkaa", "memo"
-        )));
+    public String updateArticle(
+            @PathVariable Long articleId,
+            ArticleRequest articleRequest,
+            @AuthenticationPrincipal BoardPrincipal boardPrincipal) {
+        articleService.updateArticle(articleId, articleRequest.toDto(boardPrincipal.toDto()));
 
         return "redirect:/articles/" + articleId;
     }
 
     @PostMapping("/{articleId}/delete")
-    public String deleteArticle(@PathVariable Long articleId) {
-        //TODO : 인증정보 필요
-        articleService.deleteArticle(articleId);
+    public String deleteArticle(@PathVariable Long articleId, @AuthenticationPrincipal BoardPrincipal boardPrincipal) {
+        articleService.deleteArticle(articleId, boardPrincipal.getUsername());
 
         return "redirect:/articles";
     }

--- a/fc-project-board/src/main/java/com/fc/projectboard/dto/response/ArticleCommentResponse.java
+++ b/fc-project-board/src/main/java/com/fc/projectboard/dto/response/ArticleCommentResponse.java
@@ -10,11 +10,12 @@ public record ArticleCommentResponse(
         String content,
         LocalDateTime createdAt,
         String email,
-        String nickname
+        String nickname,
+        String userId
 ) {
 
-    public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {
-        return new ArticleCommentResponse(id, content, createdAt, email, nickname);
+    public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname, String userId) {
+        return new ArticleCommentResponse(id, content, createdAt, email, nickname, userId);
     }
 
     public static ArticleCommentResponse from(ArticleCommentDto dto) {
@@ -27,7 +28,8 @@ public record ArticleCommentResponse(
                 dto.content(),
                 dto.createdAt(),
                 dto.userAccountDto().email(),
-                nickname
+                nickname,
+                dto.userAccountDto().userId()
         );
     }
 }

--- a/fc-project-board/src/main/java/com/fc/projectboard/dto/response/ArticleWithCommentsResponse.java
+++ b/fc-project-board/src/main/java/com/fc/projectboard/dto/response/ArticleWithCommentsResponse.java
@@ -15,11 +15,12 @@ public record ArticleWithCommentsResponse(
         LocalDateTime createdAt,
         String email,
         String nickname,
+        String userId,
         Set<ArticleCommentResponse> articleCommentResponses
 ) {
 
-    public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentResponse> articleCommentResponses) {
-        return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, articleCommentResponses);
+    public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, String userId, Set<ArticleCommentResponse> articleCommentResponses) {
+        return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, userId, articleCommentResponses);
     }
 
     public static ArticleWithCommentsResponse from(ArticleWithCommentsDto dto) {
@@ -36,6 +37,7 @@ public record ArticleWithCommentsResponse(
                 dto.createdAt(),
                 dto.userAccountDto().email(),
                 nickname,
+                dto.userAccountDto().userId(),
                 dto.articleCommentDtos().stream()
                         .map(ArticleCommentResponse::from)
                         .collect(Collectors.toCollection(LinkedHashSet::new))

--- a/fc-project-board/src/main/java/com/fc/projectboard/dto/security/BoardPrincipal.java
+++ b/fc-project-board/src/main/java/com/fc/projectboard/dto/security/BoardPrincipal.java
@@ -1,0 +1,102 @@
+package com.fc.projectboard.dto.security;
+
+import com.fc.projectboard.dto.UserAccountDto;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record BoardPrincipal (
+        String username,
+        String password,
+        Collection<? extends GrantedAuthority> authorities,
+        String email,
+        String nickname,
+        String memo
+) implements UserDetails {
+
+    public static BoardPrincipal of(String username, String password, String email, String nickname, String memo) {
+        Set<RoleType> roleTypes = Set.of(RoleType.USER);
+        return new BoardPrincipal(
+                username,
+                password,
+                roleTypes.stream()
+                        .map(RoleType::getName)
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toUnmodifiableSet()),
+                email,
+                nickname,
+                memo
+        );
+    }
+
+    public static BoardPrincipal from(UserAccountDto dto) {
+        return BoardPrincipal.of(
+                dto.userId(),
+                dto.userPassword(),
+                dto.email(),
+                dto.nickname(),
+                dto.memo()
+        );
+    }
+
+    public UserAccountDto toDto() {
+        return UserAccountDto.of(
+                username,
+                password,
+                email,
+                nickname,
+                memo
+        );
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    public enum RoleType {
+        USER("ROLE_USER");
+
+        @Getter
+        private final String name;
+
+        RoleType(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/fc-project-board/src/main/java/com/fc/projectboard/repository/ArticleCommentRepository.java
+++ b/fc-project-board/src/main/java/com/fc/projectboard/repository/ArticleCommentRepository.java
@@ -20,6 +20,8 @@ public interface ArticleCommentRepository extends
 
     List<ArticleComment> findByArticle_Id(Long articleId);
 
+    void deleteByIdAndUserAccount_UserId(Long articleCommentId, String userId);
+
     @Override
     default void customize(QuerydslBindings bindings, QArticleComment root) {
         bindings.excludeUnlistedProperties(true);

--- a/fc-project-board/src/main/java/com/fc/projectboard/repository/ArticleRepository.java
+++ b/fc-project-board/src/main/java/com/fc/projectboard/repository/ArticleRepository.java
@@ -26,6 +26,8 @@ public interface ArticleRepository extends
     Page<Article> findByUserAccount_NicknameContaining(String nickname, Pageable pageable);
     Page<Article> findByHashtag(String hashtag, Pageable pageable);
 
+    void deleteByIdAndUserAccount_UserId(Long articleId, String userId);
+
     @Override
     default void customize(QuerydslBindings bindings, QArticle root) {
         bindings.excludeUnlistedProperties(true); // 필터링 리스트 초기화

--- a/fc-project-board/src/main/java/com/fc/projectboard/service/ArticleCommentService.java
+++ b/fc-project-board/src/main/java/com/fc/projectboard/service/ArticleCommentService.java
@@ -54,7 +54,7 @@ public class ArticleCommentService {
         }
     }
 
-    public void deleteArticleComment(Long articleCommentId) {
-        articleCommentRepository.deleteById(articleCommentId);
+    public void deleteArticleComment(Long articleCommentId, String userId) {
+        articleCommentRepository.deleteByIdAndUserAccount_UserId(articleCommentId, userId);
     }
 }

--- a/fc-project-board/src/main/java/com/fc/projectboard/service/ArticleService.java
+++ b/fc-project-board/src/main/java/com/fc/projectboard/service/ArticleService.java
@@ -65,18 +65,23 @@ public class ArticleService {
     public void updateArticle(Long articleId, ArticleDto dto) {
         try {
             Article article = articleRepository.getReferenceById(articleId);
-            if (StringUtils.isNotEmpty(dto.title()))
-                article.setTitle(dto.title());
-            if (StringUtils.isNotEmpty(dto.content()))
-                article.setContent(dto.content());
+            UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());
+
+            if (article.getUserAccount().equals(userAccount)) {
+                if (StringUtils.isNotEmpty(dto.title()))
+                    article.setTitle(dto.title());
+                if (StringUtils.isNotEmpty(dto.content()))
+                    article.setContent(dto.content());
+            }
+
             article.setHashtag(dto.hashtag());
         } catch (EntityNotFoundException e) {
-            log.warn("Article update was failed by article is not found - dto: {}", dto);
+            log.warn("Article update was failed by article is not found or user is not matches - {}", e.getLocalizedMessage());
         }
     }
 
-    public void deleteArticle(long articleId) {
-        articleRepository.deleteById(articleId);
+    public void deleteArticle(long articleId, String userId) {
+        articleRepository.deleteByIdAndUserAccount_UserId(articleId, userId);
     }
 
     public long getArticleCount() {

--- a/fc-project-board/src/main/resources/application.yaml
+++ b/fc-project-board/src/main/resources/application.yaml
@@ -38,3 +38,9 @@ spring:
 
   thymeleaf3:
     decoupled-logic: true
+
+  devtools:
+    livereload:
+      enabled: false
+    restart:
+      enabled: false

--- a/fc-project-board/src/main/resources/data.sql
+++ b/fc-project-board/src/main/resources/data.sql
@@ -1,8 +1,8 @@
 -- 테스트 계정 추가
 -- TODO : 테스트용이지만 비밀번호가 노출된 데이터가 세팅됨, 개선 필요
 insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at, modified_by)
-values ('fkaa', 'asdf1234', 'fkaa', 'wlgus120332@gmail.com', 'I am fkaa', now(), 'fkaa', now(), 'fkaa'),
-       ('fkaa2', 'asdf12342', 'fkaa2', 'wlgus12033222@gmail.com', 'I am fkaa2', now(), 'fkaa2', now(), 'fkaa2');
+values ('fkaa', '{noop}asdf1234', 'fkaa', 'wlgus120332@gmail.com', 'I am fkaa', now(), 'fkaa', now(), 'fkaa'),
+       ('fkaa2', '{noop}asdf12342', 'fkaa2', 'wlgus12033222@gmail.com', 'I am fkaa2', now(), 'fkaa2', now(), 'fkaa2');
 
 -- 123개의 게시글 insert
 insert into article (user_id, title, content, hashtag, created_by, modified_by, created_at, modified_at)

--- a/fc-project-board/src/main/resources/templates/articles/detail.html
+++ b/fc-project-board/src/main/resources/templates/articles/detail.html
@@ -64,27 +64,36 @@
                             <input type="hidden" class="article-id">
                             <div class="row">
                                 <div class="col-md-10 col-lg-9">
-                                    <strong>Uno</strong>
+                                    <strong>Fkaa</strong>
                                     <small><time>2022-01-01</time></small>
                                     <p>
                                         Lorem ipsum dolor sit amet, consectetur adipiscing elit.<br>
                                         Lorem ipsum dolor sit amet
                                     </p>
                                 </div>
-                                <div class="col-2 mb-3">
+                                <div class="col-2 mb-3 align-items-center">
                                     <button type="submit" class="btn btn-outline-danger" id="delete-comment-button">삭제</button>
                                 </div>
                             </div>
                         </form>
                     </li>
                     <li>
-                        <div>
-                            <strong>Fkaa2</strong>
-                            <small><time>2023-01-02</time></small>
-                            <p>
-                                blah blah
-                            </p>
-                        </div>
+                        <form class="comment-form">
+                            <input type="hidden" class="article-id">
+                            <div class="row">
+                                <div class="col-md-10 col-lg-9">
+                                    <strong>Fkaa</strong>
+                                    <small><time>2022-01-01</time></small>
+                                    <p>
+                                        Lorem ipsum dolor sit amet, consectetur adipiscing elit.<br>
+                                        Lorem ipsum dolor sit amet
+                                    </p>
+                                </div>
+                                <div class="col-2 mb-3 align-items-center">
+                                    <button type="submit" class="btn btn-outline-danger" hidden>삭제</button>
+                                </div>
+                            </div>
+                        </form>
                     </li>
                     <li>
                         <div>

--- a/fc-project-board/src/main/resources/templates/articles/detail.th.xml
+++ b/fc-project-board/src/main/resources/templates/articles/detail.th.xml
@@ -12,7 +12,7 @@
         <attr sel="#article-content/pre" th:text="*{content}" />
     </attr>
 
-    <attr sel="#article-buttons">
+    <attr sel="#article-buttons" th:if="${#authorization.expression('isAuthenticated()')} and *{userId} == ${#authentication.name}">
         <attr sel="#delete-article-form" th:action="'/articles/' + *{id} + '/delete'" th:method="post">
             <attr sel="#update-article" th:href="'/articles/' + *{id} + '/form'"/>
         </attr>
@@ -29,6 +29,7 @@
                 <attr sel="div/strong" th:text="${articleComment.nickname}" />
                 <attr sel="div/small/time" th:datetime="${articleComment.createdAt}" th:text="${#temporals.format(articleComment.createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
                 <attr sel="div/p" th:text="${articleComment.content}" />
+                <attr sel="button" th:if="${#authorization.expression('isAuthenticated()')} and ${articleComment.userId} == ${#authentication.name}" />
             </attr>
         </attr>
     </attr>

--- a/fc-project-board/src/main/resources/templates/articles/index.th.xml
+++ b/fc-project-board/src/main/resources/templates/articles/index.th.xml
@@ -58,7 +58,7 @@
             </attr>
         </attr>
 
-        <attr sel="#write-article" th:href="@{/articles/form}" />
+        <attr sel="#write-article" sec:authorize="isAuthenticacted()" th:href="@{/articles/form}" />
 
         <attr sel="#pagination">
             <attr sel="li[0]/a"

--- a/fc-project-board/src/main/resources/templates/header.html
+++ b/fc-project-board/src/main/resources/templates/header.html
@@ -15,8 +15,9 @@
                 </ul>
                 
                 <div class="text-end">
-                    <button type="button" class="btn btn-outline-light me-2">Login</button>
-                    <button type="button" class="btn btn-warning">Sign-up</button>
+                    <span id="username" class="text-white me-2">username</span>
+                    <a role="button" id="login" class="btn btn-outline-light me-2">Login</a>
+                    <a role="button" id="logout" class="btn btn-outline-light me-2">Logout</a>
                 </div>
             </div>
         </div>

--- a/fc-project-board/src/main/resources/templates/header.th.xml
+++ b/fc-project-board/src/main/resources/templates/header.th.xml
@@ -2,4 +2,7 @@
 <thlogic>
     <attr sel="#home" th:href="@{/}" />
     <attr sel="#hashtag" th:href="@{/articles/search-hashtag}" />
+    <attr sel="#username" sec:authorize="isAuthenticated()" sec:authentication="name" />
+    <attr sel="#login" sec:authorize="!isAuthenticated()" th:href="@{/login}" />
+    <attr sel="#logout" sec:authorize="isAuthenticated()" th:href="@{/logout}" />
 </thlogic>

--- a/fc-project-board/src/test/java/com/fc/projectboard/config/TestSecurityConfig.java
+++ b/fc-project-board/src/test/java/com/fc/projectboard/config/TestSecurityConfig.java
@@ -1,0 +1,30 @@
+package com.fc.projectboard.config;
+
+import com.fc.projectboard.domain.UserAccount;
+import com.fc.projectboard.repository.UserAccountRepository;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.event.annotation.BeforeTestMethod;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@Import(SecurityConfig.class)
+public class TestSecurityConfig {
+
+    @MockBean
+    private UserAccountRepository  userAccountRepository;
+
+    @BeforeTestMethod
+    public void securitySetup() {
+        given(userAccountRepository.findById(anyString())).willReturn(Optional.of(UserAccount.of(
+                "fkaaTest",
+                "pw",
+                "test@email.com",
+                "test",
+                "test memo"
+        )));
+    }
+}

--- a/fc-project-board/src/test/java/com/fc/projectboard/controller/ArticleCommentControllerTest.java
+++ b/fc-project-board/src/test/java/com/fc/projectboard/controller/ArticleCommentControllerTest.java
@@ -1,6 +1,7 @@
 package com.fc.projectboard.controller;
 
 import com.fc.projectboard.config.SecurityConfig;
+import com.fc.projectboard.config.TestSecurityConfig;
 import com.fc.projectboard.dto.ArticleCommentDto;
 import com.fc.projectboard.dto.request.ArticleCommentRequest;
 import com.fc.projectboard.service.ArticleCommentService;
@@ -12,6 +13,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Map;
@@ -21,11 +24,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.willDoNothing;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("View 컨트롤러 - 댓글")
-@Import({SecurityConfig.class, FormDataEncoder.class})
+@Import({TestSecurityConfig.class, FormDataEncoder.class})
 @WebMvcTest(ArticleCommentController.class)
 class ArticleCommentControllerTest {
 
@@ -39,6 +43,7 @@ class ArticleCommentControllerTest {
         this.formDataEncoder = formDataEncoder;
     }
 
+    @WithUserDetails(value = "fkaaTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("[view][POST] 댓글 등록 - 정상 호출")
     @Test
     void givenArticleCommentInfo_whenRequesting_thenSavesNewArticleComment() throws Exception {
@@ -52,21 +57,22 @@ class ArticleCommentControllerTest {
                         post("/comments/new")
                                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                                 .content(formDataEncoder.encode(request))
-                                .with(csrf())
-                )
+                                .with(csrf()))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(view().name("redirect:/articles/" + articleId))
                 .andExpect(redirectedUrl("/articles/" + articleId));
         then(articleCommentService).should().saveArticleComment(any(ArticleCommentDto.class));
     }
 
+    @WithUserDetails(value = "fkaaTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("[view][POST] 댓글 삭제 - 정상 호출")
     @Test
     void givenArticleCommentIdToDelete_whenRequesting_thenDeletesArticleComment() throws Exception {
         // Given
         long articleId = 1L;
         long articleCommentId = 1L;
-        willDoNothing().given(articleCommentService).deleteArticleComment(articleCommentId);
+        String userId = "fkaaTest";
+        willDoNothing().given(articleCommentService).deleteArticleComment(articleCommentId, userId);
 
         // When & Then
         mvc.perform(
@@ -78,6 +84,6 @@ class ArticleCommentControllerTest {
                 .andExpect(status().is3xxRedirection())
                 .andExpect(view().name("redirect:/articles/" + articleId))
                 .andExpect(redirectedUrl("/articles/" + articleId));
-        then(articleCommentService).should().deleteArticleComment(articleCommentId);
+        then(articleCommentService).should().deleteArticleComment(articleCommentId, userId);
     }
 }

--- a/fc-project-board/src/test/java/com/fc/projectboard/repository/JpaRepositoryTest.java
+++ b/fc-project-board/src/test/java/com/fc/projectboard/repository/JpaRepositoryTest.java
@@ -1,22 +1,26 @@
 package com.fc.projectboard.repository;
 
-import com.fc.projectboard.config.JpaConfig;
 import com.fc.projectboard.domain.Article;
 import com.fc.projectboard.domain.UserAccount;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ActiveProfiles("testdb")
 @DisplayName("JPA 연결 테스트")
-@Import(JpaConfig.class)
+@Import(JpaRepositoryTest.TestJapConfig.class)
 @DataJpaTest
 class JpaRepositoryTest {
 
@@ -96,5 +100,15 @@ class JpaRepositoryTest {
         //then
         assertThat(articleRepository.count()).isEqualTo(previousArticleCount - 1);
         assertThat(articleCommentRepository.count()).isEqualTo(previousArticleCommentCount - deletedCommentsSize);
+    }
+
+    @EnableJpaAuditing
+    @TestConfiguration
+    public static class TestJapConfig {
+
+        @Bean
+        public AuditorAware<String> auditorAware() {
+            return () -> Optional.of("fkaa");
+        }
     }
 }

--- a/fc-project-board/src/test/java/com/fc/projectboard/service/ArticleCommentServiceTest.java
+++ b/fc-project-board/src/test/java/com/fc/projectboard/service/ArticleCommentServiceTest.java
@@ -125,13 +125,14 @@ class ArticleCommentServiceTest {
     void givenArticleCommentId_whenDeletingArticleComment_thenDeletesArticleComment() {
         // Given
         Long articleCommentId = 1L;
-        willDoNothing().given(articleCommentRepository).deleteById(articleCommentId);
+        String userId = "fkaa";
+        willDoNothing().given(articleCommentRepository).deleteByIdAndUserAccount_UserId(articleCommentId, userId);
 
         // When
-        sut.deleteArticleComment(articleCommentId);
+        sut.deleteArticleComment(articleCommentId, userId);
 
         // Then
-        then(articleCommentRepository).should().deleteById(articleCommentId);
+        then(articleCommentRepository).should().deleteByIdAndUserAccount_UserId(articleCommentId, userId);
     }
 
 

--- a/fc-project-board/src/test/java/com/fc/projectboard/service/ArticleServiceTest.java
+++ b/fc-project-board/src/test/java/com/fc/projectboard/service/ArticleServiceTest.java
@@ -159,6 +159,7 @@ class ArticleServiceTest {
         Article article = createArticle();
         ArticleDto dto = createArticleDto("새 타이틀", "새 내용", "#springboot");
         given(articleRepository.getReferenceById(dto.id())).willReturn(article);
+        given(userAccountRepository.getReferenceById(dto.userAccountDto().userId())).willReturn(dto.userAccountDto().toEntity());
 
         // When
         sut.updateArticle(dto.id(), dto);
@@ -169,6 +170,7 @@ class ArticleServiceTest {
                 .hasFieldOrPropertyWithValue("content", dto.content())
                 .hasFieldOrPropertyWithValue("hashtag", dto.hashtag());
         then(articleRepository).should().getReferenceById(dto.id());
+        then(userAccountRepository).should().getReferenceById(dto.userAccountDto().userId());
     }
 
     @DisplayName("없는 게시글의 수정 정보를 입력하면, 경고 로그를 찍고 아무 것도 하지 않는다.")
@@ -190,13 +192,14 @@ class ArticleServiceTest {
     void givenArticleId_whenDeletingArticle_thenDeletesArticle() {
         // Given
         Long articleId = 1L;
-        willDoNothing().given(articleRepository).deleteById(articleId);
+        String userId = "fkaa";
+        willDoNothing().given(articleRepository).deleteByIdAndUserAccount_UserId(articleId, userId);
 
         // When
-        sut.deleteArticle(1L);
+        sut.deleteArticle(1L, userId);
 
         // Then
-        then(articleRepository).should().deleteById(articleId);
+        then(articleRepository).should().deleteByIdAndUserAccount_UserId(articleId, userId);
     }
 
     @DisplayName("게시글 수를 조회하면, 게시글 수를 반환")


### PR DESCRIPTION
### Spring Security를 활용한 인증 기능 구현

- Spring Security를 활용하여 인증기능 구현
  - 인증이 필요없는 부분 설정
    - `루트 페이지`, `게시글 목록 페이지`, `해시태그 검색 페이지`
  - 외의 페이지는 모두 인증 후 접속 가능하도록 구현
- 패스워드 인코더 추가
- ~~뷰 추가 후 PR merge 예정~~
- 뷰 추가에 대한 PR 수정
  - 헤더 뷰 수정
    - 인증 정보에 따른 로그인 및 로그아웃 버튼의 노출 변경
  - 게시글 작성의 인증정보에 따른 노출 변경
  - 게시글 상세의 수정 및 삭제, 댓글의 삭제의 인증정보에 따른 노출 변경

This closes #33 