### PR TITLE
[고도화][리팩터링] Equals & Hashcode의 참조 ID 변경

### DIFF
--- a/src/main/java/com/fc/projectboard/domain/Article.java
+++ b/src/main/java/com/fc/projectboard/domain/Article.java
@@ -54,11 +54,11 @@ public class Article extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Article article)) return false;
-        return id != null && id.equals(article.id);
+        return this.getId() != null && this.getId().equals(article.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/fc/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/fc/projectboard/domain/ArticleComment.java
@@ -41,12 +41,12 @@ public class ArticleComment extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof ArticleComment that)) return false;
-        return id.equals(that.id);
+        if (!(o instanceof ArticleComment articleComment)) return false;
+        return this.getId() != null && this.getId().equals(articleComment.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/fc/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/fc/projectboard/domain/UserAccount.java
@@ -51,12 +51,12 @@ public class UserAccount extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount that)) return false;
-        return userId.equals(that.userId);
+        return this.getUserId() != null && this.getUserId().equals(that.userId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 
 }


### PR DESCRIPTION
### Entity의 Equals & Hashcode의 필드 접근 방법 변경

> 개요
- #65 와 같음

> 작업내용
- 각 Entity(`Article`, `ArticleComment`, `UserAccount`)의 Equals & Hashcode의 필드 접근을 직접 접근에서 `Getter`를 통한 접근으로 변경

This closese #65 