### PR TITLE
[고도화] DB Migration(MySQL -> PostgreSQL)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'org.apache.commons:commons-lang3'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'mysql:mysql-connector-java'
+	runtimeOnly 'org.postgresql:postgresql'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,10 +13,11 @@ logging:
 
 spring:
   datasource:
-      url: jdbc:mysql://localhost:3306/board
+#      url: jdbc:mysql://localhost:3306/board
+      url: jdbc:postgresql://localhost:5432/board
       username: fkaa
-      password: thisisTESTpw!@#$
-      driver-class-name: com.mysql.cj.jdbc.Driver
+      password: 1234
+#      driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     defer-datasource-initialization: true
     hibernate:


### PR DESCRIPTION
> ### 개요
- DB를 MySQL에서 PostgreSQL로 변경하는 요구사항에 따라 DB Migration 진행
  - 요구사항의 경우 가상의 요구사항으로 설정하고, DB 변경과 Migration을 학습하기 위한 목적
- This closes #71 

---
> ### 작업 내용
- `PostgreSQL`의 Local 설치
- 프로젝트 의존성 추가(PostgreSQL Driver)
- Application.yaml에서 DB 프로퍼티를 MySQL에서 PostgreSQL로 변경

---
> ### 특이사항
- DB 변경 및 Migration 작업 내역은 Datagrip 또는 Intellij의 Database 서브탭에서 확인 가능
- 실제 앱에서 확인은 #70 에서 언급된 대로 현재 기능의 미구현으로 정상적인 확인이 불가능
- 상세 기능의 구현에 따라 앱에서 DB 데이터 확인 가능