### PR TITLE
[고도화] 해시태그 검색 기능 고도화

### DIFF
--- a/src/main/java/com/fc/projectboard/controller/ArticleController.java
+++ b/src/main/java/com/fc/projectboard/controller/ArticleController.java
@@ -42,6 +42,7 @@ public class ArticleController {
         map.addAttribute("articles", articles);
         map.addAttribute("paginationBarNumbers", barNumbers);
         map.addAttribute("searchTypes", SearchType.values());
+        map.addAttribute("searchTypeHashtag", SearchType.HASHTAG);
 
         return "articles/index";
     }
@@ -56,6 +57,7 @@ public class ArticleController {
         map.addAttribute("article", article);
         map.addAttribute("articleComments", article.articleCommentResponses());
         map.addAttribute("totalCount", articleService.getArticleCount());
+        map.addAttribute("searchTypeHashtag", SearchType.HASHTAG);
 
         return "articles/detail";
     }

--- a/src/main/java/com/fc/projectboard/repository/ArticleRepository.java
+++ b/src/main/java/com/fc/projectboard/repository/ArticleRepository.java
@@ -15,24 +15,25 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 @RepositoryRestResource
 public interface ArticleRepository extends
-        JpaRepository<Article, Long>
-        , ArticleRepositoryCustom
-        , QuerydslPredicateExecutor<Article>
-        , QuerydslBinderCustomizer<QArticle> {
+        JpaRepository<Article, Long>,
+        ArticleRepositoryCustom,
+        QuerydslPredicateExecutor<Article>,
+        QuerydslBinderCustomizer<QArticle> {
 
     Page<Article> findByTitleContaining(String title, Pageable pageable);
     Page<Article> findByContentContaining(String content, Pageable pageable);
     Page<Article> findByUserAccount_UserIdContaining(String userId, Pageable pageable);
     Page<Article> findByUserAccount_NicknameContaining(String nickname, Pageable pageable);
 
-    void deleteByIdAndUserAccount_UserId(Long articleId, String userId);
+    void deleteByIdAndUserAccount_UserId(Long articleId, String userid);
 
     @Override
     default void customize(QuerydslBindings bindings, QArticle root) {
-        bindings.excludeUnlistedProperties(true); // 필터링 리스트 초기화
-        bindings.including(root.title, root.content, root.createdAt, root.createdBy); //필터링 리스트 셋업
-        bindings.bind(root.title).first(StringExpression::containsIgnoreCase); // search param은 first(하나) / StringExpression으로 대소문자 구분 없이 조회(like 검색)
+        bindings.excludeUnlistedProperties(true);
+        bindings.including(root.title, root.content, root.hashtags, root.createdAt, root.createdBy);
+        bindings.bind(root.title).first(StringExpression::containsIgnoreCase);
         bindings.bind(root.content).first(StringExpression::containsIgnoreCase);
+        bindings.bind(root.hashtags.any().hashtagName).first(StringExpression::containsIgnoreCase);
         bindings.bind(root.createdAt).first(DateTimeExpression::eq);
         bindings.bind(root.createdBy).first(StringExpression::containsIgnoreCase);
     }

--- a/src/main/java/com/fc/projectboard/service/HashtagService.java
+++ b/src/main/java/com/fc/projectboard/service/HashtagService.java
@@ -1,19 +1,48 @@
 package com.fc.projectboard.service;
 
+import com.fc.projectboard.domain.Hashtag;
+import com.fc.projectboard.repository.HashtagRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+@RequiredArgsConstructor
+@Transactional
 @Service
 public class HashtagService {
-    public Object parseHashtagNames(String content) {
-        return null;
+
+    private final HashtagRepository hashtagRepository;
+
+    @Transactional(readOnly = true)
+    public Set<Hashtag> findHashtagsByNames(Set<String> hashtagNames) {
+        return new HashSet<>(hashtagRepository.findByHashtagNameIn(hashtagNames));
     }
 
-    public Object findHashtagsByNames(Set<String> expectedHashtagNames) {
-        return null;
+    public Set<String> parseHashtagNames(String content) {
+        if (content == null) {
+            return Set.of();
+        }
+
+        Pattern pattern = Pattern.compile("#[\\w가-힣]+");
+        Matcher matcher = pattern.matcher(content.strip());
+        Set<String> result = new HashSet<>();
+
+        while (matcher.find()) {
+            result.add(matcher.group().replace("#", ""));
+        }
+
+        return Set.copyOf(result);
     }
 
-    public void deleteHashtagWithoutArticles(Object any) {
+    public void deleteHashtagWithoutArticles(Long hashtagId) {
+        Hashtag hashtag = hashtagRepository.getReferenceById(hashtagId);
+        if (hashtag.getArticles().isEmpty()) {
+            hashtagRepository.delete(hashtag);
+        }
     }
 }

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -26,7 +26,7 @@
                     <p><span id="nickname">Fkaa</span></p>
                     <p><a id="email" href="mailto:fkaa@gmail.com">wlgus120332@gmail.com</a></p>
                     <p><time id="created-at" datetime="2023-02-24T00:00:00">2022-02-24</time></p>
-                    <p><span id="hashtag">#java</span></p>
+                    <p><span id="hashtag" class="badge text-bg-secondary mx-1"><a class="text-reset">#java</a></span></p>
                 </aside>
             </section>
             
@@ -107,9 +107,9 @@
                 </ul>
             </section>
         </div>
-        
+    
         <div class="row g-5">
-            <nav id="pagenation" aria-label="Page navigation">
+            <nav id="pagination" aria-label="Page navigation">
                 <ul class="pagination">
                     <li class="page-item">
                         <a class="page-link" href="#" aria-label="Previous">
@@ -118,12 +118,13 @@
                     </li>
                     <li class="page-item">
                         <a class="page-link" href="#" aria-label="Next">
-                            <span aria-hidden="true">next &raquo; </span>
+                            <span aria-hidden="true">next &raquo;</span>
                         </a>
                     </li>
                 </ul>
             </nav>
         </div>
+    </main>
         
     </main>
     

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -1,49 +1,55 @@
-<?xml version="1.0" ?>
+<?xml version="1.0"?>
 <thlogic>
-    <attr sel="#header" th:replace="~{header::header}"/>
-    <attr sel="#footer" th:replace="~{footer::footer}"/>
+    <attr sel="#header" th:replace="header :: header" />
+    <attr sel="#footer" th:replace="footer :: footer" />
 
     <attr sel="#article-main" th:object="${article}">
         <attr sel="#article-header/h1" th:text="*{title}" />
         <attr sel="#nickname" th:text="*{nickname}" />
         <attr sel="#email" th:text="*{email}" />
-        <attr sel="#created-at" th:datetime="*{createdAt}" th:text="*{#temporals.format(createdAt, 'yyyy-MM-dd')}" />
-        <attr sel="#hashtag" th:text="*{hashtag}" />
-        <attr sel="#article-content/pre" th:text="*{content}" />
-    </attr>
-
-    <attr sel="#article-buttons" th:if="${#authorization.expression('isAuthenticated()')} and *{userId} == ${#authentication.name}">
-        <attr sel="#delete-article-form" th:action="'/articles/' + *{id} + '/delete'" th:method="post">
-            <attr sel="#update-article" th:href="'/articles/' + *{id} + '/form'"/>
+        <attr sel="#created-at" th:datetime="*{createdAt}" th:text="*{#temporals.format(createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
+        <attr sel="#hashtag" th:each="hashtag : ${article.hashtags}">
+            <attr sel="a"
+                  th:text="'#' + ${hashtag}"
+                  th:href="@{/articles(searchType=${searchTypeHashtag},searchValue=${hashtag})}"
+            />
         </attr>
-    </attr>
 
-    <attr sel=".article-id" th:name="articleId" th:value="*{id}" />
-    <attr sel="#comment-form" th:action="@{/comments/new}" th:method="post">
-        <attr sel="#comment-textbox" th:name="content" />
-    </attr>
+        <attr sel="#article-content/pre" th:text="*{content}" />
 
-    <attr sel="#article-comments" th:remove="all-but-first" >
-        <attr sel="li[0]" th:each="articleComment : ${articleComments}" >
-            <attr sel="form" th:action="'/comments/' + ${articleComment.id} + '/delete'" th:method="post">
-                <attr sel="div/strong" th:text="${articleComment.nickname}" />
-                <attr sel="div/small/time" th:datetime="${articleComment.createdAt}" th:text="${#temporals.format(articleComment.createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
-                <attr sel="div/p" th:text="${articleComment.content}" />
-                <attr sel="button" th:if="${#authorization.expression('isAuthenticated()')} and ${articleComment.userId} == ${#authentication.name}" />
+        <attr sel="#article-buttons" th:if="${#authorization.expression('isAuthenticated()')} and *{userId} == ${#authentication.name}">
+            <attr sel="#delete-article-form" th:action="'/articles/' + *{id} + '/delete'" th:method="post">
+                <attr sel="#update-article" th:href="'/articles/' + *{id} + '/form'" />
             </attr>
         </attr>
-    </attr>
 
-    <attr sel="#pagination">
-        <attr sel="ul">
-            <attr sel="li[0]/a"
-                  th:href="*{id} - 1 <= 0 ? '#' : |/articles/*{id - 1}|"
-                  th:class="'page-link' + (*{id} - 1 <= 0 ? ' disabled' : '')"
-            />
-            <attr sel="li[1]/a"
-                  th:href="*{id} + 1 > ${totalCount} ? '#' : |/articles/*{id + 1}|"
-                  th:class="'page-link' + (*{id} + 1 > ${totalCount} ? ' disabled' : '')"
-            />
+        <attr sel=".article-id" th:name="articleId" th:value="*{id}" />
+        <attr sel="#comment-form" th:action="@{/comments/new}" th:method="post">
+            <attr sel="#comment-textbox" th:name="content" />
+        </attr>
+
+        <attr sel="#article-comments" th:remove="all-but-first">
+            <attr sel="li[0]" th:each="articleComment : ${articleComments}">
+                <attr sel="form" th:action="'/comments/' + ${articleComment.id} + '/delete'" th:method="post">
+                    <attr sel="div/strong" th:text="${articleComment.nickname}" />
+                    <attr sel="div/small/time" th:datetime="${articleComment.createdAt}" th:text="${#temporals.format(articleComment.createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
+                    <attr sel="div/p" th:text="${articleComment.content}" />
+                    <attr sel="button" th:if="${#authorization.expression('isAuthenticated()')} and ${articleComment.userId} == ${#authentication.name}" />
+                </attr>
+            </attr>
+        </attr>
+
+        <attr sel="#pagination">
+            <attr sel="ul">
+                <attr sel="li[0]/a"
+                      th:href="*{id} - 1 <= 0 ? '#' : |/articles/*{id - 1}|"
+                      th:class="'page-link' + (*{id} - 1 <= 0 ? ' disabled' : '')"
+                />
+                <attr sel="li[1]/a"
+                      th:href="*{id} + 1 > ${totalCount} ? '#' : |/articles/*{id + 1}|"
+                      th:class="'page-link' + (*{id} + 1 > ${totalCount} ? ' disabled' : '')"
+                />
+            </attr>
         </attr>
     </attr>
 </thlogic>

--- a/src/main/resources/templates/articles/form.html
+++ b/src/main/resources/templates/articles/form.html
@@ -1,60 +1,53 @@
 <!DOCTYPE html>
 <html lang="ko">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="">
-  <meta name="author" content="fkaa">
-  <title>새 게시글 등록</title>
-  
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
-</head>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="description" content="">
+        <meta name="author" content="fkaa">
+        <title>새 게시글 등록</title>
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+    </head>
 
-<body>
-
-<header id="header">
-  헤더 삽입부
-  <hr>
-</header>
-
-<div class="container">
-  <header id="article-form-header" class="py-5 text-center">
-    <h1>게시글 작성</h1>
-  </header>
-  
-  <form id="article-form">
-    <div class="row mb-3 justify-content-md-center">
-      <label for="title" class="col-sm-2 col-lg-1 col-form-label text-sm-end">제목</label>
-      <div class="col-sm-8 col-lg-9">
-        <input type="text" class="form-control" id="title" name="title" required>
-      </div>
-    </div>
-    <div class="row mb-3 justify-content-md-center">
-      <label for="content" class="col-sm-2 col-lg-1 col-form-label text-sm-end">본문</label>
-      <div class="col-sm-8 col-lg-9">
-        <textarea class="form-control" id="content" name="content" rows="5" required></textarea>
-      </div>
-    </div>
-    <div class="row mb-4 justify-content-md-center">
-      <label for="hashtag" class="col-sm-2 col-lg-1 col-form-label text-sm-end">해시태그</label>
-      <div class="col-sm-8 col-lg-9">
-        <input type="text" class="form-control" id="hashtag" name="hashtag">
-      </div>
-    </div>
-    <div class="row mb-5 justify-content-md-center">
-      <div class="col-sm-10 d-grid gap-2 d-sm-flex justify-content-sm-end">
-        <button type="submit" class="btn btn-primary" id="submit-button">저장</button>
-        <button type="button" class="btn btn-secondary" id="cancel-button">취소</button>
-      </div>
-    </div>
-  </form>
-</div>
-
-<footer id="footer">
-  <hr>
-  푸터 삽입부
-</footer>
-
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2" crossorigin="anonymous"></script>
-</body>
+    <body>
+    
+        <header id="header">
+            헤더 삽입부
+            <hr>
+        </header>
+    
+        <div class="container">
+            <header id="article-form-header" class="py-5 text-center">
+                <h1>게시글 작성</h1>
+            </header>
+        
+            <form id="article-form">
+                <div class="row mb-3 justify-content-md-center">
+                    <label for="title" class="col-sm-2 col-lg-1 col-form-label text-sm-end">제목</label>
+                    <div class="col-sm-8 col-lg-9">
+                        <input type="text" class="form-control" id="title" name="title" required>
+                    </div>
+                </div>
+                <div class="row mb-3 justify-content-md-center">
+                    <label for="content" class="col-sm-2 col-lg-1 col-form-label text-sm-end">본문</label>
+                    <div class="col-sm-8 col-lg-9">
+                        <textarea class="form-control" id="content" name="content" rows="5" required></textarea>
+                    </div>
+                </div>
+                <div class="row mb-5 justify-content-md-center">
+                    <div class="col-sm-10 d-grid gap-2 d-sm-flex justify-content-sm-end">
+                        <button type="submit" class="btn btn-primary" id="submit-button">저장</button>
+                        <button type="button" class="btn btn-secondary" id="cancel-button">취소</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    
+        <footer id="footer">
+            <hr>
+            푸터 삽입부
+        </footer>
+    
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2" crossorigin="anonymous"></script>
+    </body>
 </html>

--- a/src/main/resources/templates/articles/form.th.xml
+++ b/src/main/resources/templates/articles/form.th.xml
@@ -8,7 +8,6 @@
     <attr sel="#article-form" th:action="${formStatus?.update} ? '/articles/' + ${article.id} + '/form' : '/articles/form'" th:method="post">
         <attr sel="#title" th:value="${article?.title} ?: _" />
         <attr sel="#content" th:text="${article?.content} ?: _" />
-        <attr sel="#hashtag" th:value="${article?.hashtag} ?: _" />
         <attr sel="#submit-button" th:text="${formStatus?.description} ?: _" />
         <attr sel="#cancel-button" th:onclick="'history.back()'" />
     </attr>

--- a/src/main/resources/templates/articles/index.html
+++ b/src/main/resources/templates/articles/index.html
@@ -66,7 +66,7 @@
                 <tbody>
                     <tr>
                         <td class="title"><a>첫 글</a></td>
-                        <td class="hashtag">#java</td>
+                        <td class="hashtag"><span class="badge text-bg-secondary mx-1"><a class="text-reset">#java</a></span></td>
                         <td class="user-id">fkaa</td>
                         <td class="created-at"><time>2023-01-01</time></td>
                     </tr>
@@ -78,7 +78,7 @@
                     </tr>
                     <tr>
                         <td>세번째 글</td>
-                        <td>#java</td>
+                        <td class="hashtag"><span class="badge text-bg-secondary mx-1"><a class="text-reset">#java</a></span></td>
                         <td>fkaa</td>
                         <td><time>2023-01-03</time></td>
                     </tr>

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -28,7 +28,7 @@
                 <attr sel="th.hashtag/a"
                       th:text="'해시태그'"
                       th:href="@{/articles(page=${articles.number}
-                                           , sort='hashtag' + (*{sort.getOrderFor('hashtag')} != null ? (*{sort.getOrderFor('hashtag').direction.name} != 'DESC' ? ',desc' : '') : '')
+                                           , sort='hashtags' + (*{sort.getOrderFor('hashtags')} != null ? (*{sort.getOrderFor('hashtags').direction.name} != 'DESC' ? ',desc' : '') : '')
                                            , searchType=${param.searchType}
                                            , searchValue=${param.searchValue}
                 )}"/>
@@ -51,14 +51,19 @@
             <attr sel="tbody" th:remove="all-but-first">
                 <attr sel="tr[0]" th:each="article : ${articles}">
                     <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}" />
-                    <attr sel="td.hashtag" th:text="${article.hashtag}" />
+                    <attr sel="td.hashtag/span" th:each="hashtag : ${article.hashtags}">
+                        <attr sel="a"
+                              th:text="'#' + ${hashtag}"
+                              th:href="@{/articles(searchType=${searchTypeHashtag},searchValue=${hashtag})}"
+                        />
+                    </attr>
                     <attr sel="td.user-id" th:text="${article.nickname}" />
                     <attr sel="td.created-at/time" th:datetime="${article.createdAt}" th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}" />
                 </attr>
             </attr>
         </attr>
 
-        <attr sel="#write-article" sec:authorize="isAuthenticacted()" th:href="@{/articles/form}" />
+        <attr sel="#write-article" sec:authorize="isAuthenticated()" th:href="@{/articles/form}" />
 
         <attr sel="#pagination">
             <attr sel="li[0]/a"

--- a/src/main/resources/templates/footer.html
+++ b/src/main/resources/templates/footer.html
@@ -10,7 +10,7 @@
         
         
         <ul class="nav col-md-4 justify-content-end">
-            <li class="nav-item"><a href="/static" class="nav-link px-2 text-muted">Home</a></li>
+            <li class="nav-item"><a href="/" class="nav-link px-2 text-muted">Home</a></li>
         </ul>
     </footer>
 </body>

--- a/src/test/java/com/fc/projectboard/controller/ArticleControllerTest.java
+++ b/src/test/java/com/fc/projectboard/controller/ArticleControllerTest.java
@@ -172,19 +172,6 @@ class ArticleControllerTest {
         then(articleService).should().getArticleCount();
     }
 
-    @Disabled("구현 중")
-    @DisplayName("[view][GET] 게시글 검색 전용 페이지 - 정상 호출")
-    @Test
-    void givenNothing_whenRequestingArticleSearchView_thenReturnsArticleSearchView() throws Exception {
-        // Given
-
-        // When & Then
-        mvc.perform(get("/articles/search"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
-                .andExpect(view().name("articles/search"));
-    }
-
     @DisplayName("[view][GET] 게시글 해시태그 검색 페이지 - 정상 호출")
     @Test
     void givenNothing_whenRequestingArticleSearchHashtagView_thenReturnsArticleSearchHashtagView() throws Exception {

--- a/src/test/java/com/fc/projectboard/service/HashtagServiceTest.java
+++ b/src/test/java/com/fc/projectboard/service/HashtagServiceTest.java
@@ -1,0 +1,106 @@
+package com.fc.projectboard.service;
+
+import com.fc.projectboard.domain.Hashtag;
+import com.fc.projectboard.repository.HashtagRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@DisplayName("비즈니스 로직 - 해시태그")
+@ExtendWith(MockitoExtension.class)
+class HashtagServiceTest {
+
+    @InjectMocks private HashtagService sut;
+
+    @Mock private HashtagRepository hashtagRepository;
+
+    @DisplayName("본문을 파싱하면, 해시태그 이름들을 중복없이 반환한다.")
+    @MethodSource
+    @ParameterizedTest(name = "[{index}] \"{0}\" => {1}")
+    void givenContent_whenParsing_thenReturnsUniqueHashtagNames(String input, Set<String> expected) throws Exception {
+        //given
+
+        //when
+        Set<String> actual = sut.parseHashtagNames(input);
+
+        //then
+        assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+        then(hashtagRepository).shouldHaveNoInteractions();
+    }
+
+    static Stream<Arguments> givenContent_whenParsing_thenReturnsUniqueHashtagNames() {
+        return Stream.of(
+                arguments(null, Set.of()),
+                arguments("", Set.of()),
+                arguments("   ", Set.of()),
+                arguments("#", Set.of()),
+                arguments("  #", Set.of()),
+                arguments("#   ", Set.of()),
+                arguments("java", Set.of()),
+                arguments("java#", Set.of()),
+                arguments("ja#va", Set.of("va")),
+                arguments("#java", Set.of("java")),
+                arguments("#java_spring", Set.of("java_spring")),
+                arguments("#java-spring", Set.of("java")),
+                arguments("#_java_spring", Set.of("_java_spring")),
+                arguments("#-java-spring", Set.of()),
+                arguments("#_java_spring__", Set.of("_java_spring__")),
+                arguments("#java#spring", Set.of("java", "spring")),
+                arguments("#java #spring", Set.of("java", "spring")),
+                arguments("#java  #spring", Set.of("java", "spring")),
+                arguments("#java   #spring", Set.of("java", "spring")),
+                arguments("#java     #spring", Set.of("java", "spring")),
+                arguments("  #java     #spring ", Set.of("java", "spring")),
+                arguments("   #java     #spring   ", Set.of("java", "spring")),
+                arguments("#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java #spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#spring #부트", Set.of("java", "spring", "부트")),
+                arguments("#java,#spring,#부트", Set.of("java", "spring", "부트")),
+                arguments("#java.#spring;#부트", Set.of("java", "spring", "부트")),
+                arguments("#java|#spring:#부트", Set.of("java", "spring", "부트")),
+                arguments("#java #spring  #부트", Set.of("java", "spring", "부트")),
+                arguments("   #java,? #spring  ...  #부트 ", Set.of("java", "spring", "부트")),
+                arguments("#java#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#java#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#spring#java#부트#java", Set.of("java", "spring", "부트")),
+                arguments("#java#스프링 아주 긴 글~~~~~~~~~~~~~~~~~~~~~", Set.of("java", "스프링")),
+                arguments("아주 긴 글~~~~~~~~~~~~~~~~~~~~~#java#스프링", Set.of("java", "스프링")),
+                arguments("아주 긴 글~~~~~~#java#스프링~~~~~~~~~~~~~~~", Set.of("java", "스프링")),
+                arguments("아주 긴 글~~~~~~#java~~~~~~~#스프링~~~~~~~~", Set.of("java", "스프링"))
+        );
+    }
+
+    @DisplayName("해시태그 이름들을 입력하면, 저장된 해시태그 중 이름에 매칭하는 것들을 중복 없이 반환한다.")
+    @Test
+    void givenHashtagNames_whenFindingHashtags_thenReturnsHashtagSet() {
+        // Given
+        Set<String> hashtagNames = Set.of("java", "spring", "boots");
+        given(hashtagRepository.findByHashtagNameIn(hashtagNames)).willReturn(List.of(
+                Hashtag.of("java"),
+                Hashtag.of("spring")
+        ));
+
+        // When
+        Set<Hashtag> hashtags = sut.findHashtagsByNames(hashtagNames);
+
+        // Then
+        assertThat(hashtags).hasSize(2);
+        then(hashtagRepository).should().findByHashtagNameIn(hashtagNames);
+    }
+
+}


### PR DESCRIPTION
> ### 개요
- 해시태그 기능의 고도화로 인해 새롭게 도메인이 설계되었고, 그 도메인에 대한 기능 고도화가 진행됨
- #70 과 관련되어 TODO로 남아있던 항목 본 PR에서 정리됨
  - 테스트 코드의 통과 실패
  - 해시태그 도메인의 상세기능구현
- This closes #73  

> ### 작업 내역
- 해시태그 도메인의 상세 기능 구현
- 연관된 테스트코드 리팩토링
- 해시태그 고도화 기능 관련 F/E 구현
- #72 와 관련되어 MySQL --> PostgreSQL의 DB Migration 처리 애플리케이션에서 확인

> ### 발견된 Bugfix
- F/E에서 발견된 버그 픽스
  - 로그인 후 글쓰기 버튼 하단으로 랜더링 실패 오류 수정
  - 게시글 상세페이지에서 `다음글`, `이전글` 기능 오류 수정
  - Footer의 home 버튼을 통한 페이지 이동 오류 수정